### PR TITLE
Add missing dependencies back into `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
   "bugs": {
     "url": "https://github.com/Sh1n1x/react-native-app-intro/issues"
   },
-  "homepage": "https://github.com/Sh1n1x/react-native-app-intro#readme"
+  "homepage": "https://github.com/Sh1n1x/react-native-app-intro#readme",
+  "dependencies": {
+    "assign-deep": "^0.4.6",
+    "react-native-swiper": "^1.5.13"
+  }
 }


### PR DESCRIPTION
Add dependencies back in so that they're installed as expected. Also updated dependencies to be the latest versions of each. `react-native-swiper` was previously pointing at https://github.com/FuYaoDe/react-native-swiper which may or may not have been necessary, but which has now fallen behind in development over the original, maintained repository.